### PR TITLE
Alternates cannot be the same as a reference probe. Can be introduced…

### DIFF
--- a/src/mykrobe/probes/models.py
+++ b/src/mykrobe/probes/models.py
@@ -345,6 +345,7 @@ class Panel(object):
         self.refs = unique(["".join(ref) for ref in refs])
         self.start = start
         self.alts = unique(["".join(alt) for alt in alts])
+        self.alts=list(set(self.refs)-set(self.alts))
 
 
 class Mutation(object):

--- a/tests/probe_tests/test_indel_only.py
+++ b/tests/probe_tests/test_indel_only.py
@@ -160,6 +160,24 @@ class TestINDELAlleleGenerator():
         assert panel.alts == [
             "ATCTAGCCGCAAGGGCGCGAGCAGACGCAGACGCTGGCGGGCGATCGCATGATTTGAGCTCAAATCATGCGATTC"]
 
+    def test_double_indel_fail(self):
+        v = Variant.create(
+            variant_sets=self.variant_sets,
+            reference=self.reference,
+            reference_bases="CCA",
+            start=2288851,
+            alternate_bases=["A"])
+        v1 = Variant.create(
+            variant_sets=self.variant_sets,
+            reference=self.reference,
+            reference_bases="A",
+            start=2288850,
+            alternate_bases=["ACC"])
+        context = [v1]
+        panel = self.pg2.create(v, context=context)
+        assert "GGCGCACACAATGATCGGTGGCAATACCGACCACATCGACCTCATCGACGCCGCGTTGCCGCA" in panel.refs
+        assert "GGCGCACACAATGATCGGTGGCAATACCGACCACATCGACCTCATCGACGCCGCGTTGCCGCA" not in panel.alts 
+
     def test_large_insertion(self):
         v = Variant.create(variant_sets=self.variant_sets, reference=self.reference, reference_bases="CCGCCGGCCCCGCCGTTT", start=1636155, alternate_bases=[
                            "CTGCCGGCCCCGCCGGCGCCGCCCAATCCACCGAAGCCCCTCCCTTCGGTGGGGTCGCTGCCGCCGTCGCCGCCGTCACCGCCCTTGCCGCCGGCCCCGCCGTCGCCGCCGGCTCCGGCGGTGCCGTCGCCGCCCTGGCCGCCGGCCCCGCCGTTTCCG"])


### PR DESCRIPTION
… if background/context index reverses target indel